### PR TITLE
fix: resolve the conflict between room and date filters

### DIFF
--- a/src/components/DateFilter.vue
+++ b/src/components/DateFilter.vue
@@ -29,8 +29,7 @@ export default {
   name: 'DateFilter',
   props: {
     needClearFilter      : Boolean,
-    isLoading            : Boolean,
-    filterMoveInDate     : Function
+    filterBungalows      : Function
   },
 
   data () {
@@ -62,9 +61,13 @@ export default {
       this.filterMoveInDate(this.moveInDate)
     }, 500),
 
+    debounceFilterBungalows:_.debounce(function() {
+      this.filterBungalows()
+    }, 500),
+
     updateMoveInDate () {
       this.updateRouterParams()
-      this.debounceFilterMoveInDate()
+      this.debounceFilterBungalows()
     },
   },
 
@@ -80,14 +83,6 @@ export default {
 
     menu (val) {
       val && this.$nextTick(() => (this.$refs.picker.activePicker = 'MONTH'))
-    },
-
-    isLoading: function(){
-      this.isLoading?(
-        null
-      ):(
-        this.filterMoveInDate(this.moveInDate)
-      )
     }
   }
 }

--- a/src/components/Filters.vue
+++ b/src/components/Filters.vue
@@ -27,16 +27,15 @@
       </v-flex>
       <v-flex shrink pt-1>
         <RoomFilter 
-          :filterAvaliableRooms = "filterAvaliableRooms"
-          :needClearFilter      = "needClearFilter"
-          :isLoading            = "isLoading"
+          :filterBungalows = "filterBungalows"
+          :needClearFilter = "needClearFilter"
         />
       </v-flex>
       <v-flex shrink pt-1>
         <DateFilter 
           :filterMoveInDate     = "filterMoveInDate"
+          :filterBungalows      = "filterBungalows"
           :needClearFilter      = "needClearFilter"
-          :isLoading            = "isLoading"
         />
       </v-flex>
     </v-layout>
@@ -60,9 +59,9 @@ export default {
   props: {
     selectedCity         : String,
     needClearFilter      : Boolean,
-    isLoading            : Boolean,
     filterAvaliableRooms : Function,
-    filterMoveInDate     : Function
+    filterMoveInDate     : Function,
+    filterBungalows      : Function,
   },
 
   data () {

--- a/src/components/RoomFilter.vue
+++ b/src/components/RoomFilter.vue
@@ -28,8 +28,7 @@ export default {
   name: 'RoomFilter',
   props: {
     needClearFilter      : Boolean,
-    isLoading            : Boolean,
-    filterAvaliableRooms : Function
+    filterBungalows      : Function
   },
 
   data () {
@@ -44,7 +43,7 @@ export default {
     getFilterVariableFromQuery: function(){
       if(this.avaliableRoomRange[0]!=this.filterMin || this.avaliableRoomRange[1]!=this.filterMax){
         this.avaliableRoomRange = [this.filterMin, this.filterMax]
-        this.filterAvaliableRooms(this.avaliableRoomRange)
+        this.filterBungalows()
       }
     },
 
@@ -56,13 +55,14 @@ export default {
       })
     },
 
-    debounceFilterAvaliableRooms:_.debounce(function() {
-      this.filterAvaliableRooms(this.avaliableRoomRange)
+    debounceFilterBungalows:_.debounce(function() {
+      this.filterBungalows()
     }, 500),
 
     updateFilterVarAvaliableRooms: function(){
       this.updateRouterParams()
-      this.debounceFilterAvaliableRooms()
+      // this.debounceFilterAvaliableRooms()
+      this.debounceFilterBungalows()
     },
   },
 
@@ -74,14 +74,6 @@ export default {
     needClearFilter: function(){
       this.avaliableRoomRange = [1,10];
       this.updateRouterParams();
-    },
-
-    isLoading: function(){
-      this.isLoading?(
-        null
-      ):(
-        this.filterAvaliableRooms(this.avaliableRoomRange)
-      )
     }
   }
 }

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -6,7 +6,7 @@
       :filterMoveInDate     = "filterMoveInDate"
       :selectedCity         = "selectedCity"
       :needClearFilter      = "needClearFilter"
-      :isLoading            = "isLoading"
+      :filterBungalows      = "filterBungalows"
       />
     <template v-if="isLoading ">
       <LoadingState />
@@ -71,6 +71,7 @@ export default {
         this.bungalowsCopy = response.data.results
         this.isLoading     = false
       })
+      .then( () => {this.filterBungalows()})
       .catch(e => {
         this.errors.push(e)
         this.isLoading = false
@@ -90,9 +91,20 @@ export default {
     },
 
     filterMoveInDate: function(moveInDate){
-      this.bungalows = _.filter(this.bungalowsCopy, function(bungalow) { 
+      this.bungalows = _.filter(this.bungalows, function(bungalow) { 
         return bungalow.earliest_available_date <= moveInDate
       });
+    },
+
+    filterBungalows(){
+      const moveInDate   = this.$route.query.moveInDate
+      const minRoomRange = this.$route.query.availableRoomsMin
+      const maxRoomRange = this.$route.query.availableRoomsMax
+      const avaliableRoomRange = [minRoomRange, maxRoomRange]
+
+      this.filterAvaliableRooms(avaliableRoomRange)
+      this.filterMoveInDate(moveInDate)
+
     },
 
     resetFilterStatus: function(){


### PR DESCRIPTION
The bug: room filter conflicts with the data filter. These two filters are not connected and can not be applied at the same time.

Solution: add 'filterBungalows' function in the Homepage Component. This function filters both the rooms and the move in date.